### PR TITLE
Pass in `id` to `items` and also expose `docs` from hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
   ],
   "author": "Premshree Pillai",
   "license": "ISC",
+  "peerDependencies": {
+    "react": "^16.13.1"
+  },
   "devDependencies": {
     "@types/react": "^16.9.36",
     "firebase": "^8.2.10",
     "prettier": "^2.0.5",
-    "react": "^16.13.1",
     "tslint": "^6.1.2",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.9.5"


### PR DESCRIPTION
- Move React to `peerDependencies`

Address Issue #2 
- Expose `id` as part of `items`
- Expose firestore documents from hook as `docs`