### PR TITLE
Add ability to change query and limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,64 @@ const RecentPerfumes = () => {
 export default RecentPerfumes;
 ```
 
+You can also change query during runtime. Hook will detect new query and start pagination from the beginning.
+Here is an example of controlling query's `limit` and `orderDirection` by React's state:
+
+```jsx
+type ORDER_DIRECTION = 'asc' | 'desc';
+const DEFAULT_PAGE_SIZE = 10;
+
+const RecentPerfumes = () => {
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+    const [order, setOrder] = useState<ORDER_DIRECTION>('desc');
+    const {
+        items,
+        isLoading,
+        isStart,
+        isEnd,
+        getPrev,
+        getNext,
+    } = usePagination<Perfume>(
+        firebase
+            .firestore()
+            .collection("/perfumes")
+            .orderBy("updated", order),
+        {
+            limit: pageSize
+        }
+    );
+
+    if (isLoading) {
+        return <Loading/>;
+    }
+
+    return (
+        <Grid container>
+            <Grid item xs={12}>
+                <Grid container justify="flex-end">
+                    <Grid item>
+                        <PageSizeSelect pageSize={pageSize} onChange={setPageSize} />
+                        <OrderDirectionSelect order={order} onChange={setOrder} />
+                        <IconButton onClick={getPrev} disabled={isStart}>
+                            <NavigateBeforeIcon/>
+                        </IconButton>
+                        <IconButton onClick={getNext} disabled={isEnd}>
+                            <NavgateNextIcon/>
+                        </IconButton>
+                    </Grid>
+                </Grid>
+            </Grid>
+            {items.map((perfume, idx) => {
+                return (
+                    <Grid item xs={12} sm={12} md={6} lg={6} key={`recent-perfume-${idx}`}>
+                        <PerfumeCard perfume={perfume} size="medium"/>
+                    </Grid>
+                );
+            })}
+        </Grid>
+    );
+}
+```
 ## Caveats
 
 Paginating Firestore documents relies on [query cursors](https://firebase.google.com/docs/firestore/query-data/query-cursors). It's not easy to know

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,15 @@ const usePagination = <T extends DocumentData>(firestoreQuery: Query, options: P
   const { limit = 10 } = options;
 
   useEffect(() => {
-    if (firestoreQuery !== undefined) {
+    if (firestoreQuery !== undefined ) {
+      if (
+        queryRef?.current &&
+        firestoreQuery.isEqual(queryRef.current) &&
+        limit === state.limit
+      ) {
+        return;
+      }
+
       queryRef.current = firestoreQuery;
       firstDocRef.current = undefined;
       dispatch({
@@ -161,7 +169,7 @@ const usePagination = <T extends DocumentData>(firestoreQuery: Query, options: P
         },
       });
     }
-  }, [firestoreQuery, limit]);
+  }, [firestoreQuery, limit, state.limit]);
 
   useEffect(() => {
     if (state.query !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,9 +149,8 @@ const usePagination = <T extends DocumentData>(firestoreQuery: Query, options: P
 
   useEffect(() => {
     if (firestoreQuery !== undefined) {
-      if (queryRef.current === undefined) {
-        queryRef.current = firestoreQuery;
-      }
+      queryRef.current = firestoreQuery;
+      firstDocRef.current = undefined;
       dispatch({
         type: 'SET-QUERY',
         payload: {
@@ -162,7 +161,7 @@ const usePagination = <T extends DocumentData>(firestoreQuery: Query, options: P
         },
       });
     }
-  }, []);
+  }, [firestoreQuery, limit]);
 
   useEffect(() => {
     if (state.query !== undefined) {


### PR DESCRIPTION
This pull request adds ability to change query or limit. In the current version if the query is once set it cannot be changed later. It's checking for equality between passed `firestoreQuery` and `queryRef` current value and also for `limit` parameter and `limit from state`. This is useful if you want to for example control limit or orderBy direction by external state