### PR TITLE
Return currentPage from usePagination hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ const RecentPerfumes = () => {
         isEnd,
         getPrev,
         getNext,
+        currentPage,
     } = usePagination<Perfume>(
         query(collection(db, "/perfumes"), orderBy("updated", "desc")),
         {
@@ -124,6 +125,7 @@ const RecentPerfumes = () => {
                         <IconButton onClick={getPrev} disabled={isStart}>
                             <NavigateBeforeIcon/>
                         </IconButton>
+                        <Box component="span">Page {currentPage}</Box>
                         <IconButton onClick={getNext} disabled={isEnd}>
                             <NavgateNextIcon/>
                         </IconButton>

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ interface State<T extends DocumentData> {
   isStart: boolean;
   isEnd: boolean;
   limit: number;
+  currentPage: number;
 }
 
 type ActionBase<K, V = void> = V extends void ? { type: K } : { type: K } & V;
@@ -75,6 +76,7 @@ const getReducer = <T extends DocumentData>() => (state: State<T>, action: Actio
         firstDocRef,
         limit: limitNum,
         isLoading: true,
+        currentPage: 1,
       };
     }
 
@@ -114,6 +116,7 @@ const getReducer = <T extends DocumentData>() => (state: State<T>, action: Actio
         items,
         isStart: (firstDoc && firstDocRef?.current && snapshotEqual(firstDoc, firstDocRef.current)) || false,
         isEnd: items.length < state.limit,
+        currentPage: state.currentPage,
       };
     }
 
@@ -122,6 +125,7 @@ const getReducer = <T extends DocumentData>() => (state: State<T>, action: Actio
         ...state,
         isLoading: true,
         query: state.nextQuery,
+        currentPage: state.currentPage + 1,
       };
     }
 
@@ -130,6 +134,7 @@ const getReducer = <T extends DocumentData>() => (state: State<T>, action: Actio
         ...state,
         isLoading: true,
         query: state.prevQuery,
+        currentPage: state.currentPage - 1,
       };
     }
 
@@ -154,6 +159,7 @@ const initialState = {
   isStart: true,
   isEnd: false,
   limit: 10,
+  currentPage: 1,
 };
 
 const usePagination = <T extends DocumentData>(firestoreQuery: Query, options: PaginationOptions) => {
@@ -206,6 +212,7 @@ const usePagination = <T extends DocumentData>(firestoreQuery: Query, options: P
     isEnd: state.isEnd,
     getPrev: () => dispatch({ type: 'PREV' }),
     getNext: () => dispatch({ type: 'NEXT' }),
+    currentPage: state.currentPage,
   };
 };
 


### PR DESCRIPTION
Return `currentPage` from pagination hook.

Relates to this issue: https://github.com/premshree/use-pagination-firestore/issues/9

I didn't test this change directly, but tested it extensively in this similar commit: https://github.com/examind-ai/use-pagination-firestore/commit/2ea6012048c86e05edd87cea42b5574e6b09d614